### PR TITLE
Fix wrong import for Group class

### DIFF
--- a/src/main/java/fr/insalyon/creatis/boutiques/model/BoutiquesDescriptor.java
+++ b/src/main/java/fr/insalyon/creatis/boutiques/model/BoutiquesDescriptor.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.processing.Generated;
-import javax.swing.GroupLayout.Group;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;


### PR DESCRIPTION
Wrong import for Group class introduced in https://github.com/virtual-imaging-platform/VIP-portal/pull/558, causing `objectMapper.readValue(descriptor, BoutiquesDescriptor.class)` to fail parsing descriptors with a `"groups"` section in VIP-portal.
